### PR TITLE
Fix case of directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@ module.exports = {
 
 	Slugify: require('./lib/Slugify') ,
 
-	Diacritics: require('./lib/diacritics/Diacritics') ,
+	Diacritics: require('./lib/Diacritics/Diacritics') ,
 
 	fromLocale: function(locale) {
 		return new this.Slugify(new this.Diacritics(this.requireLocale(locale)));
 	} ,
 
 	requireLocale: function(locale) {
-		return require('./lib/diacritics/locale/' + locale + '.js');
+		return require('./lib/Diacritics/locale/' + locale + '.js');
 	}
 
 };


### PR DESCRIPTION
Webpack seems to be more strict about the case of the required paths resulting in an error:

```
Unable to resolve module ./lib/diacritics/Diascritics
```

